### PR TITLE
Fix quasiquote caar reference to non-pair

### DIFF
--- a/html/quasiquotation.html
+++ b/html/quasiquotation.html
@@ -174,7 +174,7 @@ And now the macro itself:
   (if (pair? x)
       (if (eq? (car x) 'unquote)
           (cadr x)
-          (if (eq? (caar x) 'unquote-splicing)
+          (if (eq? (if (pair? (car x)) (caar x) nil) 'unquote-splicing)
               (list 'append
                     (cadr (car x))
                     (list 'quasiquote (cdr x)))

--- a/library.lisp
+++ b/library.lisp
@@ -45,7 +45,7 @@
   (if (pair? x)
       (if (eq? (car x) 'unquote)
           (cadr x)
-          (if (eq? (caar x) 'unquote-splicing)
+          (if (eq? (if (pair? (car x)) (caar x) nil) 'unquote-splicing)
               (list 'append
                     (cadr (car x))
                     (list 'quasiquote (cdr x)))
@@ -196,4 +196,3 @@
 (define (not x) (if x nil t))
 
 (define (null? x) (not x))
-


### PR DESCRIPTION
Hey @lwhjp! Not sure if you're still maintaining this repo, but I think I found a little issue in the quasiquotation code, while building an implementation of your tutorial using Zig: https://github.com/jpaquim/building-lisp-zig

It seems that the `(caar x)` call fails if `(car x)` is not a pair, so I added this extra check to the quasiquote macro. Let me know what you think.